### PR TITLE
Bcgov admin

### DIFF
--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -231,8 +231,11 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
             for (final Object key : properties.keySet()) {
               final String name = key.toString();
               final String value = properties.getProperty(name);
+              System.out.println(name);
+              System.out.println(value);
               if (value != null) {
-                if (name == "cpfAdmins") {
+                if (name.equals("cpfAdmins")) {
+                  System.out.println("inside admins");
                   List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
                   for (String admin : cpf_admins) {
                     System.out.println(admin);

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -76,12 +76,6 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
       if (username.startsWith("idir:")) {
         groupNames.add(BCGOV_ALL);
         groupNames.add(BCGOV_INTERNAL);
-        for(String admin : admins){
-          if (username.endsWith(admin))
-          {
-            groupNames.add("ADMIN");
-          }
-        }
       } else if (username.startsWith("bceid:")) {
         groupNames.add(BCGOV_ALL);
         groupNames.add(BCGOV_EXTERNAL);
@@ -166,7 +160,7 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
           if (userType.equalsIgnoreCase("INTERNAL")) {
             for (String admin : admins) {
               if (username.endsWith(admin)) {
-                final Record userGroup = this.dataAccessObject.getUserGroup("ROLE_ADMIN");
+                final Record userGroup = this.dataAccessObject.getUserGroup("ADMIN");
                 this.dataAccessObject.newUserGroupAccountXref(userGroup, user);
               }
             }

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -137,7 +137,7 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
       Transaction transaction = this.dataAccessObject.newTransaction(Propagation.REQUIRES_NEW)) {
       try {
         Record user = this.dataAccessObject.getUserAccount(USER_ACCOUNT_CLASS, userGuid);
-
+        System.out.println("inside load user by name");
         final SecurityContext context = SecurityContextHolder.getContext();
         String consumerSecret = null;
         String username;
@@ -163,6 +163,18 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
 
           user = this.dataAccessObject.newUserAccount(USER_ACCOUNT_CLASS, userGuid, username,
             consumerSecret);
+
+          for (String admin : admins) {
+            System.out.println(admin);
+            if (username.endsWith(admin))
+            {
+              final Record userGroup = this.dataAccessObject.getUserGroup("ADMIN");
+              this.dataAccessObject.newUserGroupAccountXref(userGroup, user);
+              System.out.println("Added admin");
+            }
+          }
+          System.out.println("Printed list of admins");
+
         } else {
           username = user.getValue(UserAccount.CONSUMER_KEY);
 
@@ -209,27 +221,29 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
 
   private void initPropertiesFile() {
     final Path file = Paths.get("/apps/config/cpf/cpf.properties");
+    System.out.println("inside init properties file");
     if (Files.exists(file)) {
       try {
         final Properties properties = new Properties();
         try (
           FileReader reader = new FileReader(file.toFile())) {
-              properties.load(reader);
-              for (final Object key : properties.keySet()) {
-                final String name = key.toString();
-                final String value = properties.getProperty(name);
-                if (value != null) {
-                  if (key == "cpfAdmins") {
-                    List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
-                    for (String admin : cpf_admins) {
-                      admins.add(admin);
-                    }
+            properties.load(reader);
+            for (final Object key : properties.keySet()) {
+              final String name = key.toString();
+              final String value = properties.getProperty(name);
+              System.out.println(value);
+              if (value != null) {
+                if (key == "cpfAdmins") {
+                  List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
+                  for (String admin : cpf_admins) {
+                    System.out.println(admin);
+                    admins.add(admin);
                   }
                 }
-               }
+              }
+            }
           }
-      } catch (final Exception e) {
-      }
+      } catch (final Exception e) { }
     }
   }
 

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -221,7 +221,6 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
 
   private void initPropertiesFile() {
     final Path file = Paths.get("/apps/config/cpf/cpf.properties");
-    System.out.println("inside init properties file");
     if (Files.exists(file)) {
       try {
         final Properties properties = new Properties();
@@ -231,14 +230,10 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
             for (final Object key : properties.keySet()) {
               final String name = key.toString();
               final String value = properties.getProperty(name);
-              System.out.println(name);
-              System.out.println(value);
               if (value != null) {
                 if (name.equals("cpfAdmins")) {
-                  System.out.println("inside admins");
                   List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
                   for (String admin : cpf_admins) {
-                    System.out.println(admin);
                     admins.add(admin);
                   }
                 }

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -164,17 +164,17 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
           user = this.dataAccessObject.newUserAccount(USER_ACCOUNT_CLASS, userGuid, username,
             consumerSecret);
 
-          for (String admin : admins) {
-            System.out.println(admin);
-            if (username.endsWith(admin))
-            {
-              final Record userGroup = this.dataAccessObject.getUserGroup("ADMIN");
-              this.dataAccessObject.newUserGroupAccountXref(userGroup, user);
-              System.out.println("Added admin");
+          if (userType.equalsIgnoreCase("INTERNAL")) {
+            for (String admin : admins) {
+              System.out.println(admin);
+              if (username.endsWith(admin)) {
+                final Record userGroup = this.dataAccessObject.getUserGroup("ADMIN");
+                this.dataAccessObject.newUserGroupAccountXref(userGroup, user);
+                System.out.println("Added admin");
+              }
             }
+            System.out.println("Printed list of admins");
           }
-          System.out.println("Printed list of admins");
-
         } else {
           username = user.getValue(UserAccount.CONSUMER_KEY);
 

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -166,7 +166,7 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
           if (userType.equalsIgnoreCase("INTERNAL")) {
             for (String admin : admins) {
               if (username.endsWith(admin)) {
-                final Record userGroup = this.dataAccessObject.getUserGroup("ADMIN");
+                final Record userGroup = this.dataAccessObject.getUserGroup("ROLE_ADMIN");
                 this.dataAccessObject.newUserGroupAccountXref(userGroup, user);
               }
             }

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -231,9 +231,8 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
             for (final Object key : properties.keySet()) {
               final String name = key.toString();
               final String value = properties.getProperty(name);
-              System.out.println(value);
               if (value != null) {
-                if (key == "cpfAdmins") {
+                if (name == "cpfAdmins") {
                   List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
                   for (String admin : cpf_admins) {
                     System.out.println(admin);

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -137,7 +137,6 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
       Transaction transaction = this.dataAccessObject.newTransaction(Propagation.REQUIRES_NEW)) {
       try {
         Record user = this.dataAccessObject.getUserAccount(USER_ACCOUNT_CLASS, userGuid);
-        System.out.println("inside load user by name");
         final SecurityContext context = SecurityContextHolder.getContext();
         String consumerSecret = null;
         String username;
@@ -166,14 +165,11 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
 
           if (userType.equalsIgnoreCase("INTERNAL")) {
             for (String admin : admins) {
-              System.out.println(admin);
               if (username.endsWith(admin)) {
                 final Record userGroup = this.dataAccessObject.getUserGroup("ADMIN");
                 this.dataAccessObject.newUserGroupAccountXref(userGroup, user);
-                System.out.println("Added admin");
               }
             }
-            System.out.println("Printed list of admins");
           }
         } else {
           username = user.getValue(UserAccount.CONSUMER_KEY);
@@ -235,6 +231,7 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
                   List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
                   for (String admin : cpf_admins) {
                     admins.add(admin);
+                    System.out.println(admin);
                   }
                 }
               }

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -125,6 +125,8 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
         this.userAccountSecurityService.addGrantedAuthorityService(this);
       } catch (final Throwable e) {
         throw transaction.setRollbackOnly(e);
+      } finally {
+          initPropertiesFile();
       }
     }
   }

--- a/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
+++ b/cpf-bcgov-app-war/src/main/java/ca/bc/gov/cpf/web/app/SiteminderUserDetailsService.java
@@ -231,7 +231,6 @@ public class SiteminderUserDetailsService implements UserDetailsService, GroupNa
                   List<String> cpf_admins = Arrays.asList(value.split(",[ ]*"));
                   for (String admin : cpf_admins) {
                     admins.add(admin);
-                    System.out.println(admin);
                   }
                 }
               }


### PR DESCRIPTION
Set IDIR admins via cpf.properties using cpfAdmins=... entry (e.g. cpfAdmins=abolyach,dkelsey,bkelsey)
Before this change, we had to register an IDIR user by logging into the app, then manually grant privs in the DB.